### PR TITLE
ci(sonar): specify source and test folders

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -108,14 +108,15 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
-            -Dsonar.exclusions=**/__test__/**,.github/**/*
             -Dsonar.organization=bcgov-sonarcloud
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
             -Dsonar.cobertura.reportPaths=coverage/cobertura-coverage.xml
             -Dsonar.project.monorepo.enabled=false
             -Dsonar.projectKey=bcgov_nr-spar-webapp
-            -Dsonar.sources=.
-            -Dsonar.tests=src/__test__/components
+            -Dsonar.sources=src/
+            -Dsonar.exclusions=src/**/__test__/**/*
+            -Dsonar.tests=src/
+            -Dsonar.test.inclusions=src/**/__test__/**/*
 
   # Generate release notes and update new version
   release:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -130,15 +130,15 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
-            -Dsonar.exclusions=**/__test__/**,.github/**/*
-            -Dsonar.coverage.exclusions=**/__test__/**,.github/**/*
             -Dsonar.organization=bcgov-sonarcloud
             -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
             -Dsonar.cobertura.reportPaths=coverage/cobertura-coverage.xml
             -Dsonar.project.monorepo.enabled=false
             -Dsonar.projectKey=bcgov_nr-spar-webapp
-            -Dsonar.sources=.
-            -Dsonar.tests=src/__test__/components
+            -Dsonar.sources=src/
+            -Dsonar.exclusions=src/**/__test__/**/*
+            -Dsonar.tests=src/
+            -Dsonar.test.inclusions=src/**/__test__/**/*
 
   security:
     name: Security checks


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Specify the source and test folders to narrow down sonar coverage analysis. The files related to the Cypress (i.e. all code under `cypress/`), for instance, were being considered as source code to be covered by tests.

Fixes [FSADT2-341](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT2-341).

## Type of change

CI modification.

# How Has This Been Tested?

When the *Static Analysis* job of the pipeline ran.

The expected result of this change is that the code coverage will be slightly higher than the current code coverage of the main branch. This can be checked by comparing [the estimated code coverage when this PR is merged](https://sonarcloud.io/summary/new_code?id=bcgov_nr-spar-webapp&pullRequest=16) with [the main branch's current code coverage](https://sonarcloud.io/summary/overall?id=bcgov_nr-spar-webapp).


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
