### PR TITLE
fix: added navigate calls inside useEffect hook

### DIFF
--- a/src/__test__/components/__snapshots__/BCHeader.test.tsx.snap
+++ b/src/__test__/components/__snapshots__/BCHeader.test.tsx.snap
@@ -489,6 +489,7 @@ exports[`the Header component should match the snapshot 1`] = `
         >
           <a
             className="cds--side-nav__link"
+            onClick={[Function]}
           >
             <div
               className="cds--side-nav__icon cds--side-nav__icon--small"
@@ -523,6 +524,7 @@ exports[`the Header component should match the snapshot 1`] = `
         >
           <a
             className="cds--side-nav__link"
+            onClick={[Function]}
           >
             <div
               className="cds--side-nav__icon cds--side-nav__icon--small"
@@ -557,6 +559,7 @@ exports[`the Header component should match the snapshot 1`] = `
         >
           <a
             className="cds--side-nav__link"
+            onClick={[Function]}
           >
             <div
               className="cds--side-nav__icon cds--side-nav__icon--small"

--- a/src/components/BCHeader/index.tsx
+++ b/src/components/BCHeader/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import {
@@ -122,9 +122,12 @@ const listItems = [
 
 const BCHeader = () => {
   const version: string = `Version: ${env.REACT_APP_NRSPARWEBAPP_VERSION}`;
+
   const [myProfile, setMyProfile] = useState<boolean>(false);
   const [notifications, setNotifications] = useState<boolean>(false);
   const [overlay, setOverlay] = useState<boolean>(false);
+  const [goToURL, setGoToURL] = useState<string>('');
+  const [goTo, setGoTo] = useState<boolean>(false);
 
   const handleNotificationsPanel = useCallback((): void => {
     if (notifications) {
@@ -159,6 +162,13 @@ const BCHeader = () => {
   }, []);
 
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (goTo) {
+      setGoTo(false);
+      navigate(goToURL);
+    }
+  }, [goTo]);
 
   return (
     <HeaderContainer
@@ -230,7 +240,8 @@ const BCHeader = () => {
                         key={subItem.name}
                         renderIcon={IconComponent || ''}
                         onClick={() => {
-                          navigate(`${subItem.link}`);
+                          setGoToURL(subItem.link);
+                          setGoTo(true);
                         }}
                         isActive={window.location.pathname === subItem.link}
                       >

--- a/src/components/MyProfile/index.tsx
+++ b/src/components/MyProfile/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import {
@@ -37,11 +37,10 @@ const MyProfile = () => {
   const { theme, setTheme } = useThemePreference();
   const userData = KeycloakService.getUser();
 
-  const navigate = useNavigate();
+  const [goToURL, setGoToURL] = useState<string>('');
+  const [goTo, setGoTo] = useState<boolean>(false);
 
-  const goTo = useCallback((url: string) => {
-    navigate(url);
-  }, []);
+  const navigate = useNavigate();
 
   const goOut = useCallback(() => {
     if (theme === 'g100') {
@@ -61,6 +60,13 @@ const MyProfile = () => {
       localStorage.setItem('mode', 'light');
     }
   };
+
+  useEffect(() => {
+    if (goTo) {
+      setGoTo(false);
+      navigate(goToURL);
+    }
+  }, [goTo]);
 
   return (
     <>
@@ -84,7 +90,10 @@ const MyProfile = () => {
               <SideNavLink
                 key={option.header}
                 renderIcon={IconComponent || ''}
-                onClick={goTo(option.url)}
+                onClick={() => {
+                  setGoToURL(option.url);
+                  setGoTo(true);
+                }}
               >
                 {option.header}
               </SideNavLink>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Fixed spamming warnings regarding the useNavigate hook being used out of an useEffect.

[Ticket](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT2-447)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit and manual tests.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged
