### PR TITLE
fix: added required prop in Search component

### DIFF
--- a/frontend/src/views/Seedlot/MySeedlots/SeedlotDataTable/index.tsx
+++ b/frontend/src/views/Seedlot/MySeedlots/SeedlotDataTable/index.tsx
@@ -64,6 +64,7 @@ const SeedlotDataTable = ({ seedlots }:SeedlotDataTableProps) => {
         }:DataTableInterface) => (
           <TableContainer>
             <Search
+              labelText="Search"
               onChange={onInputChange}
               placeholder="Search for seedlots"
               size="lg"


### PR DESCRIPTION
# Description

This PR fix a bug in Search component, once the prop 'labelText' is marked as required but was not on the component a warning was being thrown.

For reference follows screenshot with the error:
![image](https://user-images.githubusercontent.com/118473401/228553944-83f92d47-b7b3-450f-92d8-8b9e275deda5.png)

Fixes:
[Jira Ticket](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT2-598)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested locally.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Frontend](https://nr-spar-webapp-80-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-spar-webapp/actions/workflows/merge-main.yml)